### PR TITLE
Fix reading time logic

### DIFF
--- a/reading-time/scripts/content.js
+++ b/reading-time/scripts/content.js
@@ -7,7 +7,7 @@ if (article) {
     const words = text.matchAll(wordMatchRegExp);
     // matchAll returns an iterator, convert to array to get word count
     const wordCount = [...words].length;
-    const readingTime = Math.round(wordCount / 200);
+    const readingTime = Math.max(1, Math.ceil(wordCount / 200));
     const badge = document.createElement("p");
     // Use the same styling as the article's header
     badge.classList.add("color-secondary-text", "type--caption");
@@ -17,6 +17,8 @@ if (article) {
     const heading = article.querySelector("h1, h2");
     // Support for article docs with date
     const date = article.querySelector("time")?.parentNode;
-
-    (date ?? heading).insertAdjacentElement("afterend", badge);
+    const target = date ?? heading;
+    if (target) {
+        target.insertAdjacentElement("afterend", badge);
+    }
 }


### PR DESCRIPTION
## Summary
- improve reading time calculation to never be zero
- guard against missing heading or date elements before inserting the badge

## Testing
- `node -e "require('./reading-time/scripts/content.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683f56f5a8a88326bba388a34e8764ed