### PR TITLE
Add options page for API key

### DIFF
--- a/explain-highlight/README.md
+++ b/explain-highlight/README.md
@@ -1,0 +1,14 @@
+# Explain Highlight Extension
+
+This extension lets you highlight text on any webpage and automatically fetches an explanation from ChatGPT. When you select some text, a small popup appears below the selection. The extension sends the selected text to the OpenAI API and displays the explanation in the popup.
+
+## Setup
+
+1. Obtain an OpenAI API key.
+2. Load the extension in Chrome via **chrome://extensions** > **Load unpacked** and select this folder.
+3. Click **Details** on the extension and open **Extension options**.
+4. Enter your API key in the field and click **Save**. The key is stored locally in your browser using `chrome.storage` and never sent anywhere except to the OpenAI API when making requests.
+
+## Usage
+
+Highlight any text on a webpage. A popup with "Loading..." will show near the selection and will update with the explanation once the request completes.

--- a/explain-highlight/background.js
+++ b/explain-highlight/background.js
@@ -1,0 +1,38 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'explain') {
+    chrome.storage.local.get('apiKey', async ({ apiKey }) => {
+      if (!apiKey) {
+        sendResponse({ error: 'API key not set. Open extension options to enter it.' });
+        return;
+      }
+      try {
+        const explanation = await fetchExplanation(message.text, apiKey);
+        sendResponse({ text: explanation });
+      } catch (e) {
+        console.error(e);
+        sendResponse({ error: e.message });
+      }
+    });
+    return true; // Indicates we will respond asynchronously
+  }
+});
+
+async function fetchExplanation(text, apiKey) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + apiKey
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: `Explain the following text in simple terms: \n${text}` }]
+    })
+  });
+
+  const data = await response.json();
+  if (data.error) {
+    throw new Error(data.error.message);
+  }
+  return data.choices[0].message.content.trim();
+}

--- a/explain-highlight/content.js
+++ b/explain-highlight/content.js
@@ -1,0 +1,46 @@
+let popupElement;
+
+document.addEventListener('mouseup', () => {
+  const selection = window.getSelection();
+  const text = selection.toString().trim();
+  if (!text) {
+    removePopup();
+    return;
+  }
+
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+  showPopup(rect, text);
+});
+
+function showPopup(rect, text) {
+  removePopup();
+
+  popupElement = document.createElement('div');
+  popupElement.style.position = 'absolute';
+  popupElement.style.top = `${window.scrollY + rect.bottom}px`;
+  popupElement.style.left = `${window.scrollX + rect.left}px`;
+  popupElement.style.padding = '6px 8px';
+  popupElement.style.background = '#fff';
+  popupElement.style.border = '1px solid #ccc';
+  popupElement.style.boxShadow = '0 2px 6px rgba(0,0,0,0.2)';
+  popupElement.style.zIndex = 2147483647;
+  popupElement.textContent = 'Loading...';
+
+  document.body.appendChild(popupElement);
+
+  chrome.runtime.sendMessage({ type: 'explain', text }, (response) => {
+    if (response && response.text) {
+      popupElement.textContent = response.text;
+    } else {
+      popupElement.textContent = response.error || 'Failed to get explanation';
+    }
+  });
+}
+
+function removePopup() {
+  if (popupElement && popupElement.parentNode) {
+    popupElement.parentNode.removeChild(popupElement);
+    popupElement = null;
+  }
+}

--- a/explain-highlight/manifest.json
+++ b/explain-highlight/manifest.json
@@ -1,0 +1,21 @@
+{
+    "name": "Explain Highlight",
+    "description": "Highlight text and get ChatGPT explanations.",
+    "version": "1.0",
+    "manifest_version": 3,
+    "background": {
+        "service_worker": "background.js"
+    },
+    "options_page": "options.html",
+    "permissions": ["storage"],
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content.js"],
+            "run_at": "document_end"
+        }
+    ],
+    "host_permissions": [
+        "https://api.openai.com/*"
+    ]
+}

--- a/explain-highlight/options.html
+++ b/explain-highlight/options.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Explain Highlight Options</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    label { display: block; margin-bottom: 8px; }
+    input { width: 100%; box-sizing: border-box; }
+    #status { margin-top: 10px; color: green; }
+  </style>
+</head>
+<body>
+  <h1>Explain Highlight Settings</h1>
+  <label>OpenAI API Key:
+    <input type="password" id="apiKey">
+  </label>
+  <button id="save">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/explain-highlight/options.js
+++ b/explain-highlight/options.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const apiKeyInput = document.getElementById('apiKey');
+  const statusDiv = document.getElementById('status');
+
+  chrome.storage.local.get('apiKey', ({ apiKey }) => {
+    if (apiKey) {
+      apiKeyInput.value = apiKey;
+    }
+  });
+
+  document.getElementById('save').addEventListener('click', () => {
+    const apiKey = apiKeyInput.value.trim();
+    chrome.storage.local.set({ apiKey }, () => {
+      statusDiv.textContent = 'Saved.';
+      setTimeout(() => {
+        statusDiv.textContent = '';
+      }, 1500);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add options page to enter OpenAI key using chrome.storage
- update background script to read key from storage
- document how to set the key privately in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b04cc208326a03b88cd1c1b8c1a