### PR TITLE
Improve Highlight Explainer UI

### DIFF
--- a/explain-highlight/content.js
+++ b/explain-highlight/content.js
@@ -1,4 +1,25 @@
 let popupElement;
+let styleInjected = false;
+
+function injectStyles() {
+  if (styleInjected) return;
+  const style = document.createElement('style');
+  style.textContent = `
+    .explain-popup {
+      padding: 8px 12px;
+      max-width: 320px;
+      font-family: sans-serif;
+      background: #ffffff;
+      color: #333;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+      transition: opacity 0.2s ease;
+    }
+  `;
+  document.head.appendChild(style);
+  styleInjected = true;
+}
 
 document.addEventListener('mouseup', () => {
   const selection = window.getSelection();
@@ -16,18 +37,21 @@ document.addEventListener('mouseup', () => {
 function showPopup(rect, text) {
   removePopup();
 
+  injectStyles();
+
   popupElement = document.createElement('div');
+  popupElement.className = 'explain-popup';
   popupElement.style.position = 'absolute';
   popupElement.style.top = `${window.scrollY + rect.bottom}px`;
   popupElement.style.left = `${window.scrollX + rect.left}px`;
-  popupElement.style.padding = '6px 8px';
-  popupElement.style.background = '#fff';
-  popupElement.style.border = '1px solid #ccc';
-  popupElement.style.boxShadow = '0 2px 6px rgba(0,0,0,0.2)';
   popupElement.style.zIndex = 2147483647;
+  popupElement.style.opacity = '0';
   popupElement.textContent = 'Loading...';
 
   document.body.appendChild(popupElement);
+  requestAnimationFrame(() => {
+    popupElement.style.opacity = '1';
+  });
 
   chrome.runtime.sendMessage({ type: 'explain', text }, (response) => {
     if (response && response.text) {

--- a/explain-highlight/options.css
+++ b/explain-highlight/options.css
@@ -1,0 +1,25 @@
+body {
+    font-family: 'Inter', Arial, sans-serif;
+    margin: 0;
+    padding: 24px;
+    line-height: 1.4;
+}
+
+label {
+    display: block;
+    margin-bottom: 12px;
+    font-weight: 600;
+}
+
+input {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+#status {
+    margin-top: 12px;
+    color: #20a020;
+}

--- a/explain-highlight/options.html
+++ b/explain-highlight/options.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Explain Highlight Options</title>
-  <style>
-    body { font-family: Arial, sans-serif; padding: 20px; }
-    label { display: block; margin-bottom: 8px; }
-    input { width: 100%; box-sizing: border-box; }
-    #status { margin-top: 10px; color: green; }
-  </style>
+  <link rel="stylesheet" href="options.css">
 </head>
 <body>
   <h1>Explain Highlight Settings</h1>


### PR DESCRIPTION
## Summary
- enhance popup with `.explain-popup` CSS class
- add fade-in effect and externalize popup styles
- create `options.css` and link from `options.html`
- replace inline options page styles with modern CSS

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f64e6ba2c8326b3ed5f8e2b012210